### PR TITLE
Configure automatic delivery of HealthKit data

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,19 @@ SPDX-License-Identifier: MIT
 
 # StrokeCog
 
-This repository contains the mobile application for the StrokeCog study at Stanford University.
+This repository contains the mobile application for the StrokeCog study, developed for the [Odden Research Lab](https://michelleodden.com) in the Department of Epidemiology and Population Health at the Stanford School of Medicine.
 
-The StrokeCog study was built using the [Spezi](https://github.com/StanfordSpezi/Spezi) ecosystem and builds on top of the [Stanford Spezi Template Application](https://github.com/StanfordSpezi/SpeziTemplateApplication).
+StrokeCog was built using the [Spezi](https://github.com/StanfordSpezi/Spezi) framework and digital health ecosystem developed by [Stanford Biodesign Digital Health](https://bdh.stanford.edu/).
 
+## Features
 
-## StrokeCog Features
+- Onboarding and consent process via [SpeziOnboarding](https://github.com/StanfordSpezi/SpeziOnboarding)
+- Passive location data collection
+- Maps via [Mapbox](https://www.mapbox.com/)
+- Health data collection via [SpeziHealthKit](https://github.com/stanfordspezi/spezihealthkit)
+- Daily surveys via [ResearchKit](https://www.apple.com/lae/researchkit/)
 
-- Location data collection
-- Health data collection
-- Daily surveys
+## Contributors
 
-
-## Contributing
-
-- Vishnu Ravi (vishnur@stanford.edu)
-- Sylvie Dobrota Lai (sylvied@stanford.edu)
-
-[Odden Research Lab at Stanford University](https://michelleodden.com)
+- [Vishnu Ravi](https://github.com/vishnuravi)
+- [Sylvie Dobrota Lai](https://github.com/sylvieddl)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ StrokeCog was built using the [Spezi](https://github.com/StanfordSpezi/Spezi) fr
 - Onboarding and consent process via [SpeziOnboarding](https://github.com/StanfordSpezi/SpeziOnboarding)
 - Passive location data collection
 - Maps via [Mapbox](https://www.mapbox.com/)
-- Health data collection via [SpeziHealthKit](https://github.com/stanfordspezi/spezihealthkit)
+- Health data collection via [SpeziHealthKit](https://github.com/stanfordspezi/spezihealthkit) including activity and gait metrics.
 - Daily surveys via [ResearchKit](https://www.apple.com/lae/researchkit/)
 
 ## Contributors

--- a/StrokeCog.xcodeproj/xcshareddata/xcschemes/StrokeCog.xcscheme
+++ b/StrokeCog.xcodeproj/xcshareddata/xcschemes/StrokeCog.xcscheme
@@ -78,10 +78,6 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--disableFirebase"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "--showOnboarding"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/StrokeCog/Home.swift
+++ b/StrokeCog/Home.swift
@@ -7,7 +7,6 @@
 //
 
 import SpeziAccount
-import SpeziMockWebService
 import SwiftUI
 
 
@@ -41,17 +40,14 @@ struct HomeView: View {
     return HomeView()
         .previewWith(standard: StrokeCogStandard()) {
             StrokeCogScheduler()
-            MockWebService()
             AccountConfiguration(building: details, active: MockUserIdPasswordAccountService())
         }
 }
 
 #Preview {
-    CommandLine.arguments.append("--disableFirebase") // make sure the MockWebService is displayed
     return HomeView()
         .previewWith(standard: StrokeCogStandard()) {
             StrokeCogScheduler()
-            MockWebService()
             AccountConfiguration {
                 MockUserIdPasswordAccountService()
             }

--- a/StrokeCog/Home.swift
+++ b/StrokeCog/Home.swift
@@ -45,7 +45,7 @@ struct HomeView: View {
 }
 
 #Preview {
-    return HomeView()
+    HomeView()
         .previewWith(standard: StrokeCogStandard()) {
             StrokeCogScheduler()
             AccountConfiguration {

--- a/StrokeCog/StrokeCogDelegate.swift
+++ b/StrokeCog/StrokeCogDelegate.swift
@@ -79,7 +79,7 @@ class StrokeCogDelegate: SpeziAppDelegate {
                     HKQuantityType(.appleMoveTime),
                     HKCategoryType(.sleepAnalysis)
                 ],
-                deliverySetting: .manual()
+                deliverySetting: .background(.automatic)
             )
         }
     }

--- a/StrokeCog/StrokeCogDelegate.swift
+++ b/StrokeCog/StrokeCogDelegate.swift
@@ -74,7 +74,6 @@ class StrokeCogDelegate: SpeziAppDelegate {
                     HKQuantityType(.walkingSpeed),
                     HKQuantityType(.walkingAsymmetryPercentage),
                     HKQuantityType(.appleWalkingSteadiness),
-                    HKQuantityType(.stepCount),
                     HKQuantityType(.appleStandTime),
                     HKQuantityType(.appleMoveTime),
                     HKCategoryType(.sleepAnalysis)

--- a/StrokeCog/StrokeCogStandard.swift
+++ b/StrokeCog/StrokeCogStandard.swift
@@ -17,7 +17,6 @@ import SpeziAccount
 import SpeziFirebaseAccountStorage
 import SpeziFirestore
 import SpeziHealthKit
-import SpeziMockWebService
 import SpeziOnboarding
 import SpeziQuestionnaire
 import SwiftUI
@@ -32,7 +31,6 @@ actor StrokeCogStandard: Standard, EnvironmentAccessible, HealthKitConstraint, O
         Firestore.firestore().collection("users")
     }
 
-    @Dependency var mockWebService: MockWebService?
     @Dependency var accountStorage: FirestoreAccountStorage?
 
     @AccountReference var account: Account
@@ -69,14 +67,6 @@ actor StrokeCogStandard: Standard, EnvironmentAccessible, HealthKitConstraint, O
 
 
     func add(sample: HKSample) async {
-        if let mockWebService {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-            let jsonRepresentation = (try? String(data: encoder.encode(sample.resource), encoding: .utf8)) ?? ""
-            try? await mockWebService.upload(path: "healthkit/\(sample.uuid.uuidString)", body: jsonRepresentation)
-            return
-        }
-        
         do {
             try await healthKitDocument(id: sample.id).setData(from: sample.resource)
         } catch {
@@ -85,11 +75,6 @@ actor StrokeCogStandard: Standard, EnvironmentAccessible, HealthKitConstraint, O
     }
     
     func remove(sample: HKDeletedObject) async {
-        if let mockWebService {
-            try? await mockWebService.remove(path: "healthkit/\(sample.uuid.uuidString)")
-            return
-        }
-        
         do {
             try await healthKitDocument(id: sample.uuid).delete()
         } catch {
@@ -99,13 +84,7 @@ actor StrokeCogStandard: Standard, EnvironmentAccessible, HealthKitConstraint, O
     
     func add(response: ModelsR4.QuestionnaireResponse) async {
         let id = response.identifier?.value?.value?.string ?? UUID().uuidString
-        
-        if let mockWebService {
-            let jsonRepresentation = (try? String(data: JSONEncoder().encode(response), encoding: .utf8)) ?? ""
-            try? await mockWebService.upload(path: "questionnaireResponse/\(id)", body: jsonRepresentation)
-            return
-        }
-        
+    
         do {
             try await userDocumentReference
                 .collection("QuestionnaireResponse") // Add all HealthKit sources in a /QuestionnaireResponse collection.


### PR DESCRIPTION
# Configure automatic delivery of HealthKit data

Configures automatic background delivery of the following HealthKit data types, encoded into FHIR Observations:
- [Step Count](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/1615548-stepcount)
- [Walking Speed](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/3131040-walkingspeed)
- [Walking Asymmetry Percentage](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/3552086-walkingasymmetrypercentage)
- [Apple Walking Steadiness](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/3747016-applewalkingsteadiness)
- [Apple Stand Time](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/3174858-applestandtime)
- [Apple Move Time](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/3131035-applemovetime)
- [Sleep Analysis](https://developer.apple.com/documentation/healthkit/hkcategoryvaluesleepanalysis)

The PR additionally removes the `MockWebService` which is no longer being used in this application.