### PR TITLE
Improve location permissions workflow

### DIFF
--- a/StrokeCog/Location/LocationModule.swift
+++ b/StrokeCog/Location/LocationModule.swift
@@ -69,12 +69,13 @@ public class LocationModule: NSObject, CLLocationManagerDelegate, Module, Defaul
         self.manager.stopMonitoringSignificantLocationChanges()
         logger.info("Stopping tracking...")
     }
+    
 
     public func requestAuthorizationLocation() {
         self.manager.requestWhenInUseAuthorization()
         self.manager.requestAlwaysAuthorization()
     }
-    
+
     public func fetchLocations() async {
         do {
             if let locations = try await standard?.fetchLocations() {

--- a/StrokeCog/Location/LocationModule.swift
+++ b/StrokeCog/Location/LocationModule.swift
@@ -21,7 +21,7 @@ public class LocationModule: NSObject, CLLocationManagerDelegate, Module, Defaul
     private var previousLocation: CLLocationCoordinate2D?
     private var previousDate: Date?
 
-    @Published var authorizationStatus: CLAuthorizationStatus = CLLocationManager().authorizationStatus
+    @Published var authorizationStatus = CLLocationManager().authorizationStatus
     @Published var canShowRequestMessage = true
 
     private var lastKnownLocation: CLLocationCoordinate2D? {
@@ -125,10 +125,6 @@ public class LocationModule: NSObject, CLLocationManagerDelegate, Module, Defaul
                 }
             }
         }
-    }
-
-    public func userAuthorizeAlways() -> Bool {
-        self.manager.authorizationStatus == .authorizedAlways
     }
 
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/StrokeCog/Onboarding/LocationPermissions.swift
+++ b/StrokeCog/Onboarding/LocationPermissions.swift
@@ -84,9 +84,13 @@ struct LocationPermissions: View {
             },
             actionView: {
                 OnboardingActionsView(
-                    "LOCATION_PERMISSIONS_BUTTON",
-                    action: {
+                    primaryText: "LOCATION_PERMISSIONS_BUTTON",
+                    primaryAction: {
                         locationModule.requestAuthorizationLocation()
+                    },
+                    secondaryText: "LOCATION_NO_POPUP_BUTTON",
+                    secondaryAction: {
+                        currentStep = .changeLocationSettings
                     }
                 )
             }
@@ -114,9 +118,13 @@ struct LocationPermissions: View {
             },
             actionView: {
                 OnboardingActionsView(
-                    "LOCATION_PERMISSIONS_BUTTON",
-                    action: {
+                    primaryText: "LOCATION_PERMISSIONS_BUTTON",
+                    primaryAction: {
                         locationModule.requestAuthorizationLocation()
+                    },
+                    secondaryText: "LOCATION_NO_POPUP_BUTTON",
+                    secondaryAction: {
+                        currentStep = .changeLocationSettings
                     }
                 )
             }

--- a/StrokeCog/Onboarding/LocationPermissions.swift
+++ b/StrokeCog/Onboarding/LocationPermissions.swift
@@ -11,16 +11,50 @@ import SpeziScheduler
 import SwiftUI
 
 
+// swiftlint:disable type_contents_order
 struct LocationPermissions: View {
     @Environment(OnboardingNavigationPath.self) private var onboardingNavigationPath
     @Environment(LocationModule.self) private var locationModule
     
     @State private var locationProcessing = false
+    @State private var currentStep: LocationPermissionsStep = .allowWhileUsingStep
     
     private let logger = Logger(subsystem: "StrokeCog", category: "Onboarding")
     
+    enum LocationPermissionsStep {
+        case allowWhileUsingStep
+        case changeToAlwaysAllowStep
+        case changeLocationSettingsStep
+    }
     
     var body: some View {
+        VStack(spacing: 10) {
+            switch currentStep {
+            case .allowWhileUsingStep:
+                allowWhileUsingStep
+            case .changeToAlwaysAllowStep:
+                changeToAlwaysAllowStep
+            case .changeLocationSettingsStep:
+                changeLocationSettingsStep
+            }
+        }
+        .onReceive(locationModule.$authorizationStatus) { status in
+            switch status {
+            case .authorizedAlways:
+                onboardingNavigationPath.nextStep()
+            case .authorizedWhenInUse:
+                currentStep = .changeToAlwaysAllowStep
+            case .denied, .restricted:
+                currentStep = .changeLocationSettingsStep
+            case .notDetermined:
+                currentStep = .allowWhileUsingStep
+            @unknown default:
+                currentStep = .allowWhileUsingStep
+            }
+        }
+    }
+    
+    var allowWhileUsingStep: some View {
         OnboardingView(
             contentView: {
                 VStack {
@@ -30,47 +64,86 @@ struct LocationPermissions: View {
                     )
                     Spacer()
                     Image(systemName: "mappin.and.ellipse")
-                        .font(.system(size: 150))
+                        .font(.system(size: 50))
                         .foregroundColor(.accentColor)
                         .accessibilityHidden(true)
-                    Text("LOCATION_PERMISSIONS_DESCRIPTION")
+                    Text("LOCATION_ALLOW_WHILE_USING_DESCRIPTION")
                         .multilineTextAlignment(.center)
                         .padding(.vertical, 16)
-                    Spacer()
                 }
-            }, actionView: {
+            },
+            actionView: {
                 OnboardingActionsView(
                     "LOCATION_PERMISSIONS_BUTTON",
                     action: {
-                        do {
-                            locationProcessing = true
-                            // Location authorization is not available in the preview simulator.
-                            if ProcessInfo.processInfo.isPreviewSimulator {
-                                try await _Concurrency.Task.sleep(for: .seconds(5))
-                                locationProcessing = false
-                            } else {
-                                locationModule.requestAuthorizationLocation()
-                            }
-                        } catch {
-                            logger.debug("Could not request location permissions.")
+                        locationModule.requestAuthorizationLocation()
+                    }
+                )
+            }
+        )
+    }
+    
+    var changeToAlwaysAllowStep: some View {
+        OnboardingView(
+            contentView: {
+                VStack {
+                    OnboardingTitleView(
+                        title: "LOCATION_PERMISSIONS_TITLE",
+                        subtitle: "LOCATION_PERMISSIONS_SUBTITLE"
+                    )
+                    Spacer()
+                    Image(systemName: "mappin.and.ellipse")
+                        .font(.system(size: 50))
+                        .foregroundColor(.accentColor)
+                        .accessibilityHidden(true)
+                    Text("LOCATION_CHANGE_TO_ALWAYS_ALLOW_DESCRIPTION")
+                        .multilineTextAlignment(.center)
+                        .padding(.vertical, 16)
+                }
+            },
+            actionView: {
+                OnboardingActionsView(
+                    "LOCATION_PERMISSIONS_BUTTON",
+                    action: {
+                        locationModule.requestAuthorizationLocation()
+                    }
+                )
+            }
+        )
+    }
+    
+    var changeLocationSettingsStep: some View {
+        OnboardingView(
+            contentView: {
+                VStack {
+                    OnboardingTitleView(
+                        title: "LOCATION_PERMISSIONS_TITLE",
+                        subtitle: "LOCATION_PERMISSIONS_SUBTITLE"
+                    )
+                    Spacer()
+                    Image(systemName: "mappin.and.ellipse")
+                        .font(.system(size: 50))
+                        .foregroundColor(.accentColor)
+                        .accessibilityHidden(true)
+                    Text("LOCATION_CHANGE_LOCATION_SETTINGS_DESCRIPTION")
+                        .multilineTextAlignment(.center)
+                        .padding(.vertical, 16)
+                }
+            },
+            actionView: {
+                OnboardingActionsView(
+                    "LOCATION_PERMISSIONS_BUTTON",
+                    action: {
+                        guard let settingsUrl = await URL(string: UIApplication.openSettingsURLString) else {
+                            return
+                        }
+                        if await UIApplication.shared.canOpenURL(settingsUrl) {
+                            await UIApplication.shared.open(settingsUrl)
                         }
                     }
                 )
             }
         )
-            .navigationBarBackButtonHidden(locationProcessing)
-            .navigationTitle(Text(verbatim: ""))
-            .onReceive(locationModule.$authorizationStatus) { status in
-                switch status {
-                case .authorizedWhenInUse:
-                    locationModule.requestAuthorizationLocation()
-                case .authorizedAlways:
-                    onboardingNavigationPath.nextStep()
-                    locationProcessing = false
-                default:
-                    break
-                }
-            }
     }
 }
 

--- a/StrokeCog/Onboarding/LocationPermissions.swift
+++ b/StrokeCog/Onboarding/LocationPermissions.swift
@@ -43,10 +43,10 @@ struct LocationPermissions: View {
         .onReceive(locationModule.$authorizationStatus) { status in
             switch status {
             case .authorizedAlways:
-                isFirstRequest = false
                 onboardingNavigationPath.nextStep()
             case .authorizedWhenInUse:
                 if isFirstRequest {
+                    isFirstRequest = false
                     currentStep = .changeToAlwaysAllow
                 } else {
                     currentStep = .changeLocationSettings

--- a/StrokeCog/Resources/Localizable.xcstrings
+++ b/StrokeCog/Resources/Localizable.xcstrings
@@ -285,6 +285,36 @@
         }
       }
     },
+    "LOCATION_ALLOW_WHILE_USING_DESCRIPTION" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please tap the button below and select \"Allow While Using App\" on the window that appears."
+          }
+        }
+      }
+    },
+    "LOCATION_CHANGE_LOCATION_SETTINGS_DESCRIPTION" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please go to your location settings and select \"Always\"."
+          }
+        }
+      }
+    },
+    "LOCATION_CHANGE_TO_ALWAYS_ALLOW_DESCRIPTION" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please tap the button below and select \"Change to Always Allow\" on the window that appears."
+          }
+        }
+      }
+    },
     "LOCATION_PERMISSIONS_BUTTON" : {
       "localizations" : {
         "en" : {
@@ -296,6 +326,7 @@
       }
     },
     "LOCATION_PERMISSIONS_DESCRIPTION" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/StrokeCog/Resources/Localizable.xcstrings
+++ b/StrokeCog/Resources/Localizable.xcstrings
@@ -320,7 +320,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Please go to your location settings and select \"Always\"."
+            "value" : "Please tap the button below to go to your location settings, tap \"Location\" and select \"Always\" ."
           }
         }
       }
@@ -335,23 +335,22 @@
         }
       }
     },
+    "LOCATION_NO_POPUP_BUTTON" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Window Not Appearing"
+          }
+        }
+      }
+    },
     "LOCATION_PERMISSIONS_BUTTON" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Allow Sharing Location"
-          }
-        }
-      }
-    },
-    "LOCATION_PERMISSIONS_DESCRIPTION" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To participate in the study, please allow LifeSpace to access your location."
+            "value" : "Open Location Sharing Window"
           }
         }
       }
@@ -361,7 +360,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "To participate in the study, please allow LifeSpace to access your location."
+            "value" : "To participate in the study, please allow LifeSpace to access your location. Please read the instructions below to continue."
           }
         }
       }

--- a/StrokeCog/SharedContext/StorageKeys.swift
+++ b/StrokeCog/SharedContext/StorageKeys.swift
@@ -24,4 +24,6 @@ enum StorageKeys {
     static let trackingPreference = "tracking.preference"
     
     static let lastSurveyDate = "lastSurveyDate"
+    
+    static let isFirstLocationRequest = "isFirstLocationRequest"
 }


### PR DESCRIPTION
# Improve location permissions workflow

The current location permissions workflow is confusing for users since they are shown multiple popups and are unclear on which option to select for the study. 

We split the workflow into separate steps with explanations to guide users.