### PR TITLE
Check for existing consent forms

### DIFF
--- a/StrokeCog/Onboarding/Consent.swift
+++ b/StrokeCog/Onboarding/Consent.swift
@@ -69,12 +69,14 @@ struct Consent: View {
             // Check if the user has already signed the consent forms
             self.checkingConsentForms = true
             await checkExistingConsent()
+            self.checkingConsentForms = false
+            
+            // If consent forms haven't been signed, launch the consent task
             if !existingConsent {
                 isConsentSheetPresented = true
-            } else {
-                onboardingNavigationPath.nextStep()
             }
-            self.checkingConsentForms = false
+            
+            
         }
         .overlay {
             if checkingConsentForms {

--- a/StrokeCog/Onboarding/Consent.swift
+++ b/StrokeCog/Onboarding/Consent.swift
@@ -10,6 +10,7 @@ import OSLog
 import ResearchKit
 import ResearchKitSwiftUI
 import SpeziOnboarding
+import SpeziViews
 import SwiftUI
 
 
@@ -75,34 +76,16 @@ struct Consent: View {
             if !existingConsent {
                 isConsentSheetPresented = true
             }
-            
-            
         }
-        .overlay {
-            if checkingConsentForms {
-                checkingProgressView
+        .processingOverlay(
+            isProcessing: checkingConsentForms,
+            overlay: {
+                VStack {
+                    Text("CONSENT_EXISTING_PROGRESS")
+                    ProgressView()
+                }
             }
-        }
-    }
-
-    var checkingProgressView: some View {
-        VStack {
-            Text("CONSENT_EXISTING_PROGRESS")
-            ProgressView()
-        }
-        .padding()
-        .background(Color(UIColor.systemBackground))
-        .clipShape(.rect(cornerRadius: 10))
-    }
-    
-    var savingProgressView: some View {
-        VStack {
-            Text("CONSENT_PROGRESS")
-            ProgressView()
-        }
-        .padding()
-        .background(Color(UIColor.systemBackground))
-        .clipShape(.rect(cornerRadius: 10))
+        )
     }
     
     var consentTaskView: some View {
@@ -121,11 +104,15 @@ struct Consent: View {
             self.isConsentSheetPresented = false
             onboardingNavigationPath.nextStep()
         }
-        .overlay {
-            if savingConsentForms {
-                savingProgressView
+        .processingOverlay(
+            isProcessing: checkingConsentForms,
+            overlay: {
+                VStack {
+                    Text("CONSENT_PROGRESS")
+                    ProgressView()
+                }
             }
-        }
+        )
         .ignoresSafeArea(edges: .all)
         .interactiveDismissDisabled(true)
     }

--- a/StrokeCog/Resources/Localizable.xcstrings
+++ b/StrokeCog/Resources/Localizable.xcstrings
@@ -104,7 +104,14 @@
       }
     },
     "CONSENT_EXISTING_PROGRESS" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Checking for existing consent forms..."
+          }
+        }
+      }
     },
     "CONSENT_PROGRESS" : {
       "localizations" : {

--- a/StrokeCog/Resources/Localizable.xcstrings
+++ b/StrokeCog/Resources/Localizable.xcstrings
@@ -93,6 +93,19 @@
         }
       }
     },
+    "CONSENT_EXISTING_DESCRIPTION" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have already signed the LifeSpace consent forms and can tap \"Next\" below to continue."
+          }
+        }
+      }
+    },
+    "CONSENT_EXISTING_PROGRESS" : {
+
+    },
     "CONSENT_PROGRESS" : {
       "localizations" : {
         "en" : {
@@ -321,6 +334,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Location Access"
+          }
+        }
+      }
+    },
+    "NEXT_BUTTON" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
           }
         }
       }

--- a/StrokeCog/StrokeCogStandard.swift
+++ b/StrokeCog/StrokeCogStandard.swift
@@ -269,6 +269,16 @@ actor StrokeCogStandard: Standard, EnvironmentAccessible, HealthKitConstraint, O
         }
     }
     
+    func isConsentFormUploaded(name: String) async -> Bool {
+        do {
+            let studyID = UserDefaults.standard.string(forKey: StorageKeys.studyID) ?? "unknownStudyID"
+            _ = try await userBucketReference.child("ls_consent/\(studyID)_\(name).pdf").getMetadata()
+            return true
+        } catch {
+            return false
+        }
+    }
+    
     /// Update the user document with the user's study ID
     func setStudyID(_ studyID: String) async {
         do {


### PR DESCRIPTION
# Check for existing consent forms

Currently, the application does not check for existing forms when the user is onboarding. If the user has previously onboarded with the same account and are onboarding again after deleting the app, or on a new phone, their consent forms may already be stored on Firebase. This PR checks for existing consent forms to avoid duplication.