### PR TITLE
Inject mapbox token during build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,8 @@ jobs:
           machine: api.mapbox.com
           username: mapbox
           password: ${{ secrets.MAPBOX_TOKEN }}
+      - name: Write Mapbox credentials to file for Xcode build
+        run: echo "${{ secrets.MAPBOX_TOKEN }}" > .mapbox
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ firebase-debug.*.log*
 
 # Firebase
 .firebase/
+GoogleService-Info.plist
 
 # Swift Package List
 LifeSpace/package-list.json
+
+# Mapbox token
+.mapbox

--- a/LifeSpace.xcodeproj/project.pbxproj
+++ b/LifeSpace.xcodeproj/project.pbxproj
@@ -629,7 +629,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Look for a global file named 'mapbox' or '.mapbox' within the home directory\ntoken_file=~/.mapbox\ntoken_file2=~/mapbox\ntoken=\"$(cat $token_file 2>/dev/null || cat $token_file2 2>/dev/null)\"\nif [ \"$token\" ]; then\n  plutil -replace MBXAccessToken -string $token \"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\nelse\n  echo 'warning: Missing Mapbox access token'\n  open 'https://account.mapbox.com/access-tokens/'\n  echo \"warning: Get an access token from <https://account.mapbox.com/access-tokens/>, then create a new file at $token_file or $token_file2 that contains the access token.\"\n";
+			shellScript = "# Look for a global file named 'mapbox' or '.mapbox' at the root of the project directory\ntoken_file=\"$SRCROOT/.mapbox\"\ntoken_file2=\"$SRCROOT/mapbox\"\ntoken=\"$(cat $token_file 2>/dev/null || cat $token_file2 2>/dev/null)\"\nif [ \"$token\" ]; then\n  plutil -replace MBXAccessToken -string $token \"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\nelse\n  echo 'warning: Missing Mapbox access token'\n  open 'https://account.mapbox.com/access-tokens/'\n  echo \"warning: Get an access token from <https://account.mapbox.com/access-tokens/>, then create a new file at $token_file or $token_file2 that contains the access token.\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/LifeSpace.xcodeproj/project.pbxproj
+++ b/LifeSpace.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 				653A254A283387FE005D4D48 /* Frameworks */,
 				653A254B283387FE005D4D48 /* Resources */,
 				2F5B528D29BD237B002020B7 /* ShellScript */,
+				6359C3CF2C34FA3300210E80 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -610,6 +611,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ \"${CONFIGURATION}\" = \"Debug\" ]; then\n  export PATH=\"$PATH:/opt/homebrew/bin\"\n  if which swiftlint > /dev/null; then\n    swiftlint\n  else\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\n  fi\nfi\n";
+		};
+		6359C3CF2C34FA3300210E80 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+				"$(SRCROOT)/.mapbox",
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Look for a global file named 'mapbox' or '.mapbox' within the home directory\ntoken_file=~/.mapbox\ntoken_file2=~/mapbox\ntoken=\"$(cat $token_file 2>/dev/null || cat $token_file2 2>/dev/null)\"\nif [ \"$token\" ]; then\n  plutil -replace MBXAccessToken -string $token \"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\nelse\n  echo 'warning: Missing Mapbox access token'\n  open 'https://account.mapbox.com/access-tokens/'\n  echo \"warning: Get an access token from <https://account.mapbox.com/access-tokens/>, then create a new file at $token_file or $token_file2 that contains the access token.\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/LifeSpace/LifeSpaceDelegate.swift
+++ b/LifeSpace/LifeSpaceDelegate.swift
@@ -31,9 +31,13 @@ class LifeSpaceDelegate: SpeziAppDelegate {
                         emulatorSettings: (host: "localhost", port: 9099)
                     )
                 } else {
-                    FirebaseAccountConfiguration(authenticationMethods: [.signInWithApple])
+                    FirebaseAccountConfiguration(
+                        authenticationMethods: [.signInWithApple]
+                    )
                 }
+                
                 firestore
+                
                 if FeatureFlags.useFirebaseEmulator {
                     FirebaseStorageConfiguration(emulatorSettings: (host: "localhost", port: 9199))
                 } else {

--- a/LifeSpace/Supporting Files/Info.plist
+++ b/LifeSpace/Supporting Files/Info.plist
@@ -6,8 +6,6 @@
 	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
-	<key>MBXAccessToken</key>
-	<string>TOKEN</string>
 	<key>MGLMapboxMetricsEnabledSettingShownInApp</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ SPDX-License-Identifier: MIT
 
 -->
 
+<img src="https://user-images.githubusercontent.com/1212163/167851008-e5398f1d-18ac-49e7-a24d-1529b891b965.jpg" width="300" />
+
 # LifeSpace
 
 This repository contains the LifeSpace mobile application, developed for the [Odden Research Lab](https://michelleodden.com) in the Department of Epidemiology and Population Health at the Stanford School of Medicine.


### PR DESCRIPTION
# Inject mapbox token during build

Currently the mapbox token is included in the `Info.plist` file, although this runs the risk of accidentally committing it to the repository. Instead, we create a build phase script that writes the key into the `Info.plist` file from a separate file in the root of the project that is added to the `.gitignore`.
