### PR TITLE
Move location tracking toggle to account settings

### DIFF
--- a/LifeSpace.xcodeproj/project.pbxproj
+++ b/LifeSpace.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		63A8DB292C1FE81200939757 /* AppIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = 63A8DB282C1FE81200939757 /* AppIcon.png */; };
 		63BBF8162BB8993B006890CE /* StudyIDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BBF8152BB8993B006890CE /* StudyIDView.swift */; };
 		63BBF8192BB89CF7006890CE /* studyIDs.csv in Resources */ = {isa = PBXBuildFile; fileRef = 63BBF8182BB89CF7006890CE /* studyIDs.csv */; };
+		63D86AD62C3B7F310096B9DB /* DocumentWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D86AD52C3B7F310096B9DB /* DocumentWebView.swift */; };
 		63EA5F7B2BC04F8400A48590 /* DailySurveyTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EA5F7A2BC04F8400A48590 /* DailySurveyTask.swift */; };
 		63EA5F892BC78ADD00A48590 /* DailySurveyTaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EA5F882BC78ADD00A48590 /* DailySurveyTaskView.swift */; };
 		63EA5F8C2BC78F8400A48590 /* DailySurveyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EA5F8B2BC78F8400A48590 /* DailySurveyResponse.swift */; };
@@ -147,6 +148,7 @@
 		63BBF8152BB8993B006890CE /* StudyIDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyIDView.swift; sourceTree = "<group>"; };
 		63BBF8182BB89CF7006890CE /* studyIDs.csv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = studyIDs.csv; sourceTree = "<group>"; };
 		63CC66972C204CC5001DCFDF /* LifeSpace.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = LifeSpace.xctestplan; sourceTree = "<group>"; };
+		63D86AD52C3B7F310096B9DB /* DocumentWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentWebView.swift; sourceTree = "<group>"; };
 		63EA5F7A2BC04F8400A48590 /* DailySurveyTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailySurveyTask.swift; sourceTree = "<group>"; };
 		63EA5F882BC78ADD00A48590 /* DailySurveyTaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailySurveyTaskView.swift; sourceTree = "<group>"; };
 		63EA5F8B2BC78F8400A48590 /* DailySurveyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailySurveyResponse.swift; sourceTree = "<group>"; };
@@ -407,6 +409,7 @@
 				A9720E422ABB68CC00872D23 /* AccountSetupHeader.swift */,
 				A9DFE8A82ABE551400428242 /* AccountButton.swift */,
 				639B69DA2C2BCD6A00C0FF4A /* ConsentPDFVIewer.swift */,
+				63D86AD52C3B7F310096B9DB /* DocumentWebView.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -648,6 +651,7 @@
 				639B69DB2C2BCD6A00C0FF4A /* ConsentPDFVIewer.swift in Sources */,
 				2FE5DC4529EDD7F2004B9AB4 /* Binding+Negate.swift in Sources */,
 				63497B732BBF855E001F8419 /* OptionsPanel.swift in Sources */,
+				63D86AD62C3B7F310096B9DB /* DocumentWebView.swift in Sources */,
 				2FC975A82978F11A00BA99FE /* Home.swift in Sources */,
 				2FE5DC4E29EDD7FA004B9AB4 /* ScheduleView.swift in Sources */,
 				63A28D312C0580310025A1E0 /* RefreshIcon.swift in Sources */,

--- a/LifeSpace/Account/AccountSheet.swift
+++ b/LifeSpace/Account/AccountSheet.swift
@@ -16,11 +16,13 @@ struct AccountSheet: View {
     
     @Environment(Account.self) private var account
     @Environment(\.accountRequired) var accountRequired
+    @Environment(LocationModule.self) private var locationModule
     
     @State var isInSetup = false
     @State var overviewIsEditing = false
     
     @AppStorage(StorageKeys.studyID) var studyID = "unknownStudyID"
+    @AppStorage(StorageKeys.trackingPreference) private var trackingOn = true
     
     var body: some View {
         NavigationStack {
@@ -57,45 +59,70 @@ struct AccountSheet: View {
         }
     }
     
-    var optionsList: some View {
+    private var optionsList: some View {
         List {
             Section(header: Text("STUDYID_SECTION")) {
                 Text(studyID)
             }
             Section(header: Text("DOCUMENTS_SECTION")) {
-                NavigationLink(destination: {
-                    if let url = getDocumentURL(for: "consent") {
-                        ConsentPDFViewer(url: url)
-                    } else {
-                        Text("DOCUMENT_NOT_FOUND_MESSAGE")
-                    }
-                }) {
-                    Text("VIEW_CONSENT_DOCUMENT")
-                }
-                NavigationLink(destination: {
-                    if let url = getDocumentURL(for: "hipaaAuthorization") {
-                        ConsentPDFViewer(url: url)
-                    } else {
-                        Text("DOCUMENT_NOT_FOUND_MESSAGE")
-                    }
-                }) {
-                    Text("VIEW_HIPAA_AUTHORIZATION")
-                }
-                NavigationLink(destination: EmptyView()) {
-                    Button(action: {
-                        if let url = URL(string: "https://michelleodden.com/cardinal-lifespace-privacy-policy/") {
-                            UIApplication.shared.open(url)
-                        }
-                    }) {
-                        Text("VIEW_PRIVACY_POLICY")
-                    }
-                    .buttonStyle(PlainButtonStyle())
-                }
+                consentDocumentButton
+                hipaaAuthorizationDocumentButton
+                privacyPolicyButton
+            }
+            Section(header: Text("SETTINGS_SECTION")) {
+               locationTrackingToggle
             }
         }
     }
+    
+    private var consentDocumentButton: some View {
+        NavigationLink(destination: {
+            if let url = getDocumentURL(for: "consent") {
+                ConsentPDFViewer(url: url)
+            } else {
+                Text("DOCUMENT_NOT_FOUND_MESSAGE")
+            }
+        }) {
+            Text("VIEW_CONSENT_DOCUMENT")
+        }
+    }
+    
+    private var hipaaAuthorizationDocumentButton: some View {
+        NavigationLink(destination: {
+            if let url = getDocumentURL(for: "hipaaAuthorization") {
+                ConsentPDFViewer(url: url)
+            } else {
+                Text("DOCUMENT_NOT_FOUND_MESSAGE")
+            }
+        }) {
+            Text("VIEW_HIPAA_AUTHORIZATION")
+        }
+    }
+    
+    private var privacyPolicyButton: some View {
+        NavigationLink(destination: {
+            if let url = URL(string: "https://michelleodden.com/cardinal-lifespace-privacy-policy/") {
+                DocumentWebView(url: url)
+            } else {
+                Text("DOCUMENT_NOT_FOUND_MESSAGE")
+            }
+        }) {
+            Text("VIEW_PRIVACY_POLICY")
+        }
+    }
+    
+    private var locationTrackingToggle: some View {
+        Toggle("TRACK_LOCATION_BUTTON", isOn: $trackingOn)
+            .onChange(of: trackingOn) {
+                if trackingOn {
+                    locationModule.startTracking()
+                } else {
+                    locationModule.stopTracking()
+                }
+            }
+    }
 
-    var closeButton: some ToolbarContent {
+    private var closeButton: some ToolbarContent {
         ToolbarItem(placement: .cancellationAction) {
             Button("CLOSE") {
                 dismiss()
@@ -104,7 +131,7 @@ struct AccountSheet: View {
     }
 
     
-    func getDocumentURL(for fileName: String) -> URL? {
+    private func getDocumentURL(for fileName: String) -> URL? {
         guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
             return nil
         }

--- a/LifeSpace/Account/DocumentWebView.swift
+++ b/LifeSpace/Account/DocumentWebView.swift
@@ -1,0 +1,24 @@
+//
+//  DocumentWebView.swift
+//  LifeSpace
+//
+//  Created by Vishnu Ravi on 7/7/24.
+//
+
+import SwiftUI
+import WebKit
+
+struct DocumentWebView: UIViewRepresentable {
+    typealias UIViewType = WKWebView
+    
+    let url: URL
+    
+    func makeUIView(context: Context) -> WKWebView {
+        WKWebView()
+    }
+    
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        let request = URLRequest(url: url)
+        uiView.load(request)
+    }
+}

--- a/LifeSpace/Map/LifeSpaceMapView.swift
+++ b/LifeSpace/Map/LifeSpaceMapView.swift
@@ -29,11 +29,16 @@ struct LifeSpaceMapView: View {
         NavigationStack {
             ZStack {
                 MapManagerViewWrapper()
+                
+                if !trackingOn {
+                    locationTrackingOverlay
+                }
+                
                 VStack {
                     Spacer()
                     GroupBox {
                         optionsPanelButton
-                        if self.optionsPanelOpen {
+                        if optionsPanelOpen {
                             OptionsPanel()
                         }
                     }
@@ -62,6 +67,24 @@ struct LifeSpaceMapView: View {
             if newPhase == .active {
                 refreshMap()
             }
+        }
+    }
+    
+    private var locationTrackingOverlay: some View {
+        VStack {
+            Spacer()
+            GroupBox {
+                Text("LOCATION_NOT_TRACKED")
+                    .padding()
+                Button(action: {
+                    self.trackingOn = true
+                    self.locationModule.startTracking()
+                }) {
+                    Text("TURN_TRACKING_ON")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            Spacer()
         }
     }
     

--- a/LifeSpace/Map/OptionsPanel.swift
+++ b/LifeSpace/Map/OptionsPanel.swift
@@ -38,17 +38,6 @@ struct OptionsPanel: View {
                 }
             }
         }
-        
-        GroupBox {
-            Toggle("TRACK_LOCATION_BUTTON", isOn: $trackingOn)
-                .onChange(of: trackingOn) {
-                    if trackingOn {
-                        locationModule.startTracking()
-                    } else {
-                        locationModule.stopTracking()
-                    }
-                }
-        }
     }
 }
 

--- a/LifeSpace/Resources/Localizable.xcstrings
+++ b/LifeSpace/Resources/Localizable.xcstrings
@@ -358,6 +358,16 @@
         }
       }
     },
+    "LOCATION_NOT_TRACKED" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Location tracking is off."
+          }
+        }
+      }
+    },
     "LOCATION_PERMISSIONS_BUTTON" : {
       "localizations" : {
         "en" : {
@@ -541,6 +551,16 @@
         }
       }
     },
+    "SETTINGS_SECTION" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        }
+      }
+    },
     "STUDYID_ACTION_BUTTON" : {
       "localizations" : {
         "en" : {
@@ -677,6 +697,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Track My Location"
+          }
+        }
+      }
+    },
+    "TURN_TRACKING_ON" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Turn Tracking On"
           }
         }
       }


### PR DESCRIPTION
# Move location tracking toggle to account settings

- Moves the location tracking toggle to the account settings view and removes it from the options overlay on the map view. This allows more of the map to be visible, and keeps all settings in a central location.
- Updates the privacy policy link to open the URL in a web view rather than a separate window.
- Adds an overlay on the map if tracking is off to remind the user.