### PR TITLE
Fix for survey modal

### DIFF
--- a/LifeSpace.xcodeproj/project.pbxproj
+++ b/LifeSpace.xcodeproj/project.pbxproj
@@ -804,7 +804,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LifeSpace/Supporting Files/LifeSpace.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
@@ -1008,7 +1008,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LifeSpace/Supporting Files/LifeSpace.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
@@ -1055,7 +1055,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LifeSpace/Supporting Files/LifeSpace.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;

--- a/LifeSpace/Survey/DailySurveyTaskView.swift
+++ b/LifeSpace/Survey/DailySurveyTaskView.swift
@@ -20,7 +20,9 @@ struct DailySurveyTaskView: View {
     
     
     var body: some View {
-        if SurveyModule.surveyAlreadyTaken {
+        if !showingSurvey {
+            EmptyView()
+        } else if SurveyModule.surveyAlreadyTaken {
             surveyTakenView
         } else if SurveyModule.isPreviousDaySurvey && !acknowledgedPreviousDaySurvey {
             previousDaySurveyView
@@ -140,7 +142,6 @@ struct DailySurveyTaskView: View {
             Spacer()
         }
     }
-    
     
     private func saveResponse(taskResult: ORKTaskResult) async {
         var response = DailySurveyResponse()


### PR DESCRIPTION
# Fix for survey modal

When a user opens the application during the survey window, a modal/sheet is shown asking if they wish to take the daily survey. If they choose "Yes", the survey is launched. Users reported that after completing the survey, the confirmation modal would remain. This PR addresses this issue by ensuring that the modal is completely dismissed before launching the survey. It also includes a small fix to prevent the survey from flickering when completed.
