### PR TITLE
Fix location error propagation

### DIFF
--- a/LifeSpace/Map/LifeSpaceMapView.swift
+++ b/LifeSpace/Map/LifeSpaceMapView.swift
@@ -63,11 +63,6 @@ struct LifeSpaceMapView: View {
                 }
             }
         }
-        .onChange(of: scenePhase) { _, newPhase in
-            if newPhase == .active {
-                refreshMap()
-            }
-        }
         .onAppear {
             refreshMap()
         }
@@ -111,9 +106,16 @@ struct LifeSpaceMapView: View {
     }
     
     private func refreshMap() {
+        guard !isRefreshing else { return }
+        
         Task {
             isRefreshing = true
-            await locationModule.fetchLocations()
+            do {
+                try await locationModule.fetchLocations()
+            } catch {
+                alertMessage = error.localizedDescription
+                showingSurveyAlert = true
+            }
             isRefreshing = false
         }
     }

--- a/LifeSpace/Map/LifeSpaceMapView.swift
+++ b/LifeSpace/Map/LifeSpaceMapView.swift
@@ -18,7 +18,7 @@ struct LifeSpaceMapView: View {
     @State private var presentedContext: EventContext?
     @Binding private var presentingAccount: Bool
     
-    @State private var showingSurveyAlert = false
+    @State private var showingAlert = false
     @State private var alertMessage = ""
     @State private var showingSurvey = false
     @State private var optionsPanelOpen = true
@@ -62,6 +62,13 @@ struct LifeSpaceMapView: View {
                     .disabled(isRefreshing)
                 }
             }
+        }
+        .alert("Error", isPresented: $showingAlert) {
+            Button("OK", role: .cancel) {
+                showingAlert = false
+            }
+        } message: {
+            Text(alertMessage)
         }
         .onAppear {
             refreshMap()
@@ -116,7 +123,7 @@ struct LifeSpaceMapView: View {
                 try await locationModule.fetchLocations()
             } catch {
                 alertMessage = error.localizedDescription
-                showingSurveyAlert = true
+                showingAlert = true
             }
             isRefreshing = false
         }

--- a/LifeSpace/Map/LifeSpaceMapView.swift
+++ b/LifeSpace/Map/LifeSpaceMapView.swift
@@ -14,7 +14,6 @@ import SwiftUI
 struct LifeSpaceMapView: View {
     @AppStorage(StorageKeys.trackingPreference) private var trackingOn = true
     @Environment(LocationModule.self) private var locationModule
-    @Environment(\.scenePhase) var scenePhase
     
     @State private var presentedContext: EventContext?
     @Binding private var presentingAccount: Bool
@@ -60,6 +59,7 @@ struct LifeSpaceMapView: View {
                         Image(systemName: "arrow.clockwise")
                             .accessibilityLabel("REFRESHING_MAP")
                     }
+                    .disabled(isRefreshing)
                 }
             }
         }
@@ -106,7 +106,9 @@ struct LifeSpaceMapView: View {
     }
     
     private func refreshMap() {
-        guard !isRefreshing else { return }
+        guard !isRefreshing else {
+            return
+        }
         
         Task {
             isRefreshing = true


### PR DESCRIPTION
# Fix location error propagation

- Location data fetching errors generated by the Standard are currently not being propagated back to the LocationModule, so the user is not informed. This PR makes sure errors are propagated such that the user can be notified if location data fetching fails.
- The PR also removes a redundant location data fetch.
